### PR TITLE
Fix prop velocity reset on save

### DIFF
--- a/lua/cfc_prop_restoration/core/sv/sv_adinterface.lua
+++ b/lua/cfc_prop_restoration/core/sv/sv_adinterface.lua
@@ -124,7 +124,7 @@ local function copyPlayerProps( ply )
     headEnt.Pos = ent:GetPos()
 
     local entities, constraints = AdvDupe2.duplicator.AreaCopy( entities, headEnt.Pos, true )
-    
+
     return { entities, constraints, headEnt }
 end
 

--- a/lua/cfc_prop_restoration/core/sv/sv_init.lua
+++ b/lua/cfc_prop_restoration/core/sv/sv_init.lua
@@ -163,6 +163,7 @@ local function restorePropVelocities( props )
 end
 
 local function getAllPlayerProps()
+    playerProps = {}
     for _, prop in pairs( ents.GetAll() ) do
         if IsValid( prop ) then
             local propOwner = prop:CPPIGetOwner()

--- a/lua/cfc_prop_restoration/core/sv/sv_init.lua
+++ b/lua/cfc_prop_restoration/core/sv/sv_init.lua
@@ -40,7 +40,7 @@ do
     if not ConVarExists( "cfc_proprestore_autosave_delay" ) then
         logger:debug( "Creating ConVar \"cfc_proprestore_autosave_delay\" because it does not exist." )
 
-        CreateConVar( 
+        CreateConVar(
             "cfc_proprestore_autosave_delay",
             180,
             FCVAR_ARCHIVE,

--- a/lua/cfc_prop_restoration/core/sv/sv_init.lua
+++ b/lua/cfc_prop_restoration/core/sv/sv_init.lua
@@ -193,6 +193,22 @@ local function handleChatCommands( ply, text )
 
         return ""
     end
+
+    if exp[1] == "!saveprops" then
+
+        local success, props = xpcall( ADInterface.copy, notifyOnError( ply ), ply )
+        success = success and props
+
+        if success and not table.IsEmpty( props ) and props ~= nil then
+            propData[ply:SteamID()] = props
+            addPropDataToQueue( ply, props )
+        end
+
+        ply:ChatPrint( "Saved props for restoration." )
+
+        return ""
+    end
+
 end
 
 hook.Add( "PlayerSay", "CFC_Restoration_PlayerSay", handleChatCommands )

--- a/lua/cfc_prop_restoration/core/sv/sv_init.lua
+++ b/lua/cfc_prop_restoration/core/sv/sv_init.lua
@@ -144,6 +144,8 @@ local function getPropVelocities( ply )
     local velocities = {}
     local props = playerProps[ply]
 
+    if table.IsEmpty( playerProps[ply] ) then return end
+
     for _, prop in pairs( props ) do
         local propPhys = prop:GetPhysicsObject()
         if IsValid( propPhys ) then
@@ -156,7 +158,7 @@ end
 
 
 local function restorePropVelocities( props )
-    if table.IsEmpty( playerProps ) then return end
+    if table.IsEmpty( props ) then return end
     for prop, vel in pairs( props ) do
         local propPhys = prop:GetPhysicsObject()
         if IsValid( propPhys ) then

--- a/lua/cfc_prop_restoration/core/sv/sv_init.lua
+++ b/lua/cfc_prop_restoration/core/sv/sv_init.lua
@@ -142,7 +142,7 @@ local function getPropVelocities( ply )
     local velocities = {}
     local props = playerProps[ply]
 
-    if table.Empty( props ) then return end
+    if table.IsEmpty( props ) then return end
 
     for _, prop in pairs( props ) do
         local propPhys = prop:GetPhysicsObject()
@@ -156,7 +156,7 @@ end
 
 
 local function restorePropVelocities( props )
-    if table.Empty( props ) then return end
+    if table.IsEmpty( props ) then return end
     for prop, vel in pairs( props ) do
         local propPhys = prop:GetPhysicsObject()
         if IsValid( propPhys ) then

--- a/lua/cfc_prop_restoration/core/sv/sv_init.lua
+++ b/lua/cfc_prop_restoration/core/sv/sv_init.lua
@@ -235,29 +235,6 @@ local function handleChatCommands( ply, text )
 
         return ""
     end
---remove after testing
-    if exp[1] == "!saveprops" then
-
-        local playersProps = getAllPlayerProps()
-
-        for _, ply in pairs( player.GetHumans() ) do
-
-            local propVelocities = getPropVelocities( playersProps[ply] )
-
-            local success, props = xpcall( ADInterface.copy, notifyOnError( ply ), ply )
-            success = success and props
-
-            if success and not table.IsEmpty( props ) and props ~= nil then
-                propData[ply:SteamID()] = props
-                addPropDataToQueue( ply, props )
-            end
-
-            restorePropVelocities( propVelocities )
-        end
-
-        return ""
-    end
---end
 end
 
 hook.Add( "PlayerSay", "CFC_Restoration_PlayerSay", handleChatCommands )

--- a/lua/cfc_prop_restoration/core/sv/sv_init.lua
+++ b/lua/cfc_prop_restoration/core/sv/sv_init.lua
@@ -158,7 +158,7 @@ end
 
 
 local function restorePropVelocities( props )
-    if table.IsEmpty( props ) then return end
+    if props == nil then return end
     for prop, vel in pairs( props ) do
         local propPhys = prop:GetPhysicsObject()
         if IsValid( propPhys ) then

--- a/lua/cfc_prop_restoration/core/sv/sv_init.lua
+++ b/lua/cfc_prop_restoration/core/sv/sv_init.lua
@@ -142,7 +142,7 @@ local function getPropVelocities( ply )
     local velocities = {}
     local props = playerProps[ply]
 
-    if table.IsEmpty( props ) then return end
+    if table.IsEmpty( playerProps ) then return end
 
     for _, prop in pairs( props ) do
         local propPhys = prop:GetPhysicsObject()
@@ -156,7 +156,7 @@ end
 
 
 local function restorePropVelocities( props )
-    if table.IsEmpty( props ) then return end
+    if table.IsEmpty( playerProps ) then return end
     for prop, vel in pairs( props ) do
         local propPhys = prop:GetPhysicsObject()
         if IsValid( propPhys ) then

--- a/lua/cfc_prop_restoration/core/sv/sv_init.lua
+++ b/lua/cfc_prop_restoration/core/sv/sv_init.lua
@@ -143,7 +143,10 @@ local function getPropVelocities( ply )
     local props = playerProps[ply]
 
     for _, prop in pairs( props ) do
-        velocities[prop] = prop:GetVelocity()
+        local propPhys = prop:GetPhysicsObject()
+        if IsValid( propPhys ) then
+            velocities[prop] = propPhys:GetVelocity()
+        end
     end
 
     return velocities
@@ -152,7 +155,10 @@ end
 
 local function restorePropVelocities( props )
     for prop, vel in pairs( props ) do
-        prop:SetVelocity( vel )
+        local propPhys = prop:GetPhysicsObject()
+        if IsValid( propPhys ) then
+            propPhys:SetVelocity( vel )
+        end
     end
 end
 

--- a/lua/cfc_prop_restoration/core/sv/sv_init.lua
+++ b/lua/cfc_prop_restoration/core/sv/sv_init.lua
@@ -99,7 +99,6 @@ local function processQueueData()
 
     logger:debug( "Handling queue for " .. steamid )
 
-    local time = os.time()
     local steamid64 = util.SteamIDTo64( steamid )
     local encodeData = util.TableToJSON( data )
     local fileName = restorationDirectory .. "/" .. steamid64 .. ".json"

--- a/lua/cfc_prop_restoration/core/sv/sv_init.lua
+++ b/lua/cfc_prop_restoration/core/sv/sv_init.lua
@@ -139,10 +139,10 @@ local function notifyOnError( ply )
 end
 
 local function getPropVelocities( ply )
+    if table.IsEmpty( playerProps ) then return end
+
     local velocities = {}
     local props = playerProps[ply]
-
-    if table.IsEmpty( playerProps ) then return end
 
     for _, prop in pairs( props ) do
         local propPhys = prop:GetPhysicsObject()

--- a/lua/cfc_prop_restoration/core/sv/sv_init.lua
+++ b/lua/cfc_prop_restoration/core/sv/sv_init.lua
@@ -142,6 +142,8 @@ local function getPropVelocities( ply )
     local velocities = {}
     local props = playerProps[ply]
 
+    if table.Empty( props ) then return end
+
     for _, prop in pairs( props ) do
         local propPhys = prop:GetPhysicsObject()
         if IsValid( propPhys ) then
@@ -154,6 +156,7 @@ end
 
 
 local function restorePropVelocities( props )
+    if table.Empty( props ) then return end
     for prop, vel in pairs( props ) do
         local propPhys = prop:GetPhysicsObject()
         if IsValid( propPhys ) then


### PR DESCRIPTION
I tested it using the !saveprops command which can be removed after it's all bug free. I tested the changes with no props at all and some props. I wasn't able to test it with other player props but that shouldn't change anything.