### PR TITLE
Improve restore prompt notification

### DIFF
--- a/lua/cfc_prop_restoration/core/sv/sv_init.lua
+++ b/lua/cfc_prop_restoration/core/sv/sv_init.lua
@@ -236,6 +236,10 @@ local function handleChatCommands( ply, text )
 
     if exp[1] == "!restoreprops" then
         if canRestoreProps( ply ) then
+            if notif then
+                notif:RemovePopups( ply )
+            end
+
             local data = propData[ply:SteamID()]
             if data == nil or table.IsEmpty( data ) then
                 ply:ChatPrint( "Couldn't find any props to restore." )

--- a/lua/cfc_prop_restoration/core/sv/sv_init.lua
+++ b/lua/cfc_prop_restoration/core/sv/sv_init.lua
@@ -94,7 +94,7 @@ hook.Add( "CFC_Notifications_init", "CFC_PropRestore_CreateNotif", function()
 
     notif = CFCNotifications.new( "CFC_PropRestorePrompt", "Buttons", true )
     notif:SetTitle( "Restore Props" )
-    notif:SetText( "Restore props from previous server save?\n(You can also use the !restoreprops command at any time)" )
+    notif:SetText( "Restore props from previous server save?\n(Press the button or use the !restoreprops command)" )
     notif:AddButton( "Restore", Color( 0, 255, 0 ), "restore" )
     notif:SetDisplayTime( restorePromptDuration:GetFloat() )
     notif:SetTimed( true )


### PR DESCRIPTION
This will create a convar which determines how long the on-spawn restore prompt stays up for (default 4 minutes), and adds a piece of text which informs players about the !restoreprops command